### PR TITLE
Enable circleci build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib
       - run:
           name: get libVC4CC.so url
-          command: curl "https://circleci.com/api/v1.1/project/github/nomaddo/VC4C/latest/artifacts?circle-token=${CIRCLECI_API_TOKEN}=master&filter=successful" --output /tmp/dump
+          command: curl "https://circleci.com/api/v1.1/project/github/doe300/VC4C/latest/artifacts?circle-token=${CIRCLECI_API_TOKEN}=master&filter=successful" --output /tmp/dump
       - run:
           name: get libVC4CC.so
           command: wget -O libVC4CC.so $(python tools/get_url.py "/tmp/dump")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: download header
-          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib
-      - run:
           name: get libVC4CC.so url
-          command: curl "https://circleci.com/api/v1.1/project/github/doe300/VC4C/latest/artifacts?circle-token=${CIRCLECI_API_TOKEN}=master&filter=successful" --output /tmp/dump
+          command: curl "https://circleci.com/api/v1.1/project/github/doe300/VC4C/latest/artifacts?branch=master&filter=successful" --output /tmp/dump
       - run:
           name: get libVC4CC.so
           command: wget -O libVC4CC.so $(python tools/get_url.py "/tmp/dump")
       - run:
           name: configure
-          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DCMAKE_FIND_DEBUG_MODE=1  -DOpenCL_INCLUDE_DIR=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DOpenCL_LIBRARY=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DCMAKE_INSTALL_PREFIX=/usr -DVC4CL_STDLIB_HEADER_SOURCE=./VC4CLStdLib/include/VC4CLStdLib.h -DVC4CC_LIBRARY=libVC4CC.so
+          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DOpenCL_INCLUDE_DIR=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DOpenCL_LIBRARY=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DCMAKE_INSTALL_PREFIX=/usr -DVC4CC_LIBRARY=libVC4CC.so
       - run:
           name: build
           command: make -j2
@@ -24,14 +21,11 @@ jobs:
           name: deb-packing
           command: cpack -G DEB
       - store_artifacts:
-          path: build/libVC4CC.so.0.4
-          distination: libVC4CC.so.0.4
+          path: build/libVC4CL.so.0.4
+          distination: libVC4CL.so.0.4
       - store_artifacts:
-          path: build/VC4C
-          path: VC4C
+          path: build/test/TestVC4CL
+          distination: TestVC4CL
       - store_artifacts:
-          path: build/test/TestVC4C
-          distination: TestVC4C
-      - store_artifacts:
-          path: vc4c-0.4-Linux.deb
-          distination: vc4c-0.4-Linux.deb
+          path: vc4cl-0.4-Linux.deb
+          distination: vc4cl-0.4-Linux.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: nomaddo/cross-rpi
+    steps:
+      - checkout
+      - run:
+          name: download header
+          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib
+      - run:
+          name: get libVC4CC.so url
+          command: curl "https://circleci.com/api/v1.1/project/github/nomaddo/VC4C/latest/artifacts?circle-token=${CIRCLECI_API_TOKEN}=master&filter=successful" --output /tmp/dump
+      - run:
+          name: get libVC4CC.so
+          command: wget -O libVC4CC.so $(python tools/get_url.py "/tmp/dump")
+      - run:
+          name: configure
+          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DCMAKE_FIND_DEBUG_MODE=1  -DOpenCL_INCLUDE_DIR=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DOpenCL_LIBRARY=/opt/rasberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/arm-linux-gnueabihf/include -DCMAKE_INSTALL_PREFIX=/usr -DVC4CL_STDLIB_HEADER_SOURCE=./VC4CLStdLib/include/VC4CLStdLib.h -DVC4CC_LIBRARY=libVC4CC.so
+      - run:
+          name: build
+          command: make -j2
+      - run:
+          name: deb-packing
+          command: cpack -G DEB
+      - store_artifacts:
+          path: build/libVC4CC.so.0.4
+          distination: libVC4CC.so.0.4
+      - store_artifacts:
+          path: build/VC4C
+          path: VC4C
+      - store_artifacts:
+          path: build/test/TestVC4C
+          distination: TestVC4C
+      - store_artifacts:
+          path: vc4c-0.4-Linux.deb
+          distination: vc4c-0.4-Linux.deb

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Status
 
-[![CircleCI](https://circleci.com/gh/nomaddo/VC4CL.svg?style=svg)](https://circleci.com/gh/nomaddo/VC4CL)
+[![CircleCI](https://circleci.com/gh/doe300/VC4CL.svg?style=svg)](https://circleci.com/gh/doe300/VC4CL)
 
 # VC4CL
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,7 @@
+# Status
+
+[![CircleCI](https://circleci.com/gh/nomaddo/VC4CL.svg?style=svg)](https://circleci.com/gh/nomaddo/VC4CL)
+
 # VC4CL
 
 **VC4CL** is an implementation of the **OpenCL 1.2** standard for the VideoCore IV GPU (found in all Raspberry Pi models).

--- a/tools/get_url.py
+++ b/tools/get_url.py
@@ -1,0 +1,13 @@
+import json
+import sys
+
+def main():
+  assert (len (sys.argv) == 2)
+  items = json.load (open (sys.argv[1], 'r'))
+  for item in items:
+    if item['path'].find('libVC4CC.so') > -1:
+      print (item['url'])
+      exit(0)
+  exit(1)
+
+main()


### PR DESCRIPTION
This pullreq enable circleci auto-build.

**NOTICE**
This pullreq require extra configuration in addition to ordinary setting up to `circleci`: please define

- CIRCLECI_API_TOKEN

after setting up and get the token of your `VC4C` page of circleci.
See the API doc: https://circleci.com/docs/api/v1-reference/#summary

This is for downloading latest artifacts of `VC4C`.