### PR TITLE
Fix warnings on raspbian stretch (gcc 6.3)

### DIFF
--- a/src/Buffer.cpp
+++ b/src/Buffer.cpp
@@ -99,7 +99,7 @@ Buffer* Buffer::createSubBuffer(cl_mem_flags flags, cl_buffer_create_type buffer
 	{
 		if(hostPtr != nullptr)
 		{
-			subBuffer->hostPtr = hostPtr + region->origin;
+			subBuffer->hostPtr = reinterpret_cast<uint8_t*>(hostPtr) + region->origin;
 		}
 		subBuffer->hostSize = region->size;
 		subBuffer->offset = region->origin;

--- a/src/TextureFormat.cpp
+++ b/src/TextureFormat.cpp
@@ -202,6 +202,8 @@ void* TFormatAccessor::calculatePixelOffset(void* basePointer, const std::array<
 	//for even 4K-tile rows, the sub-tiles are ordered down-left, up-left, up-right, down-right
 	//for uneven 4K-tile rows, the sub-tiles are ordered up-right, down-right, down-left, up-left
 	//for even 4K-tile rows, they are sorted left-to-right, for uneven rows right-to-left
+	assert(!"Not implemented");
+	return nullptr;
 }
 
 LTFormatAccessor::LTFormatAccessor(Image& image) : TextureAccessor(image)

--- a/src/icd_loader.cpp
+++ b/src/icd_loader.cpp
@@ -4,6 +4,12 @@
  * See the file "LICENSE" for the full license governing this code.
  */
 
+
+#ifndef CL_USE_DEPRECATED_OPENCL_1_1_APIS
+#define CL_USE_DEPRECATED_OPENCL_1_1_APIS
+#endif
+
+
 #include "icd_loader.h"
 
 #include "common.h"


### PR DESCRIPTION
This fixes 3 minor warnings, to make the whole build warning free.

Although not very important, i find it usually helps me to spot newly introduced problems.