### PR TITLE
Fixed dead link to RuntimeLibrary wiki page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Additionally the [`cl_khr_icd` extension](https://www.khronos.org/registry/OpenC
 
 The OpenCL version 1.2 was selected as target standard version, since it is the last version of the OpenCL standard where all mandatory features can be supported.
 
-VC4CL supports the **EMBEDDED PROFILE** of the OpenCL-standard, which is a trimmed version of the default **FULL PROFILE**. The most notable features, which are not supported by the VC4CL implementation are images, the `long` and `double` data-types, device-side `printf` and partitioning devices. See [RuntimeLibrary](doc/RuntimeLibrary.md) for more details of (not) supported features.
+VC4CL supports the **EMBEDDED PROFILE** of the OpenCL-standard, which is a trimmed version of the default **FULL PROFILE**. The most notable features, which are not supported by the VC4CL implementation are images, the `long` and `double` data-types, device-side `printf` and partitioning devices. See [RuntimeLibrary](https://github.com/doe300/VC4CL/wiki/RuntimeLibrary) for more details of (not) supported features.
 
 ## VideoCore IV GPU
 The VideoCore IV GPU, in the configuration as found in the Raspberry Pi models, has a theoretical maximum performance of **24 GPFLOS** and is therefore very powerful in comparison to the host CPU.


### PR DESCRIPTION
A link pointed to the docs/RuntimeLibrary.md file which was moved in 95792fc3aba5a759ba58a008ec5c309c763cde8f