### PR TITLE
Raspbian development files are required.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ The GPU (which is located on the same chip as the CPU) has 12 cores, able of run
 
 - A C++14-capable compiler (e.g. GCC 6.3 or clang from the Raspbian repositories)
 - The [VC4C](https://github.com/doe300/VC4C) compiler to compile OpenCL C-code
+- The Raspbian development files (available in the official Raspbian repository as `sudo apt-get install libraspberrypi-dev`)
 - The Khronos ICD Loader (available in the official Raspbian repository as `sudo apt-get install ocl-icd-opencl-dev ocl-icd-dev`) for building with ICD-support (e.g. allows to run several OpenCL implementations on one machine)
 - The OpenCL headers in version >= 1.2 (available in the Raspbian repositories as `sudo apt-get install opencl-headers`)
  


### PR DESCRIPTION
Solution for ticket 73 (https://github.com/doe300/VC4CL/issues/73)

From the ticket:
--------------------------
I have a new fresh Ubuntu 18.10 installation and it failed to compile due to missing Raspbian development files.

After installed the dev files it worked.
sudo apt-get install libraspberrypi-dev